### PR TITLE
Fix bash completion with different base dir

### DIFF
--- a/completions/gh.bash
+++ b/completions/gh.bash
@@ -1,13 +1,15 @@
+GH_BASE_DIR=${GH_BASE_DIR:-$HOME/src}
+
 # Add this to your .bashrc
 _complete_gh ()
 {
         COMPREPLY=()
         if [[ $COMP_CWORD -eq 1 ]]; then
-          comp_arr=$(ls $HOME/src/github.com;\
-            ls $HOME/src/github.com/$GITHUB)
+          comp_arr=$(ls $GH_BASE_DIR/github.com;\
+            ls $GH_BASE_DIR/github.com/$GITHUB)
         elif [[ $COMP_CWORD -eq 2 ]]; then
           local user=${COMP_WORDS[COMP_CWORD-1]}
-          comp_arr=$(ls $HOME/src/github.com/$user)
+          comp_arr=$(ls $GH_BASE_DIR/github.com/$user)
         else
           return 0
         fi

--- a/completions/gh.bash
+++ b/completions/gh.bash
@@ -1,5 +1,3 @@
-GH_BASE_DIR=${GH_BASE_DIR:-$HOME/src}
-
 # Add this to your .bashrc
 _complete_gh ()
 {


### PR DESCRIPTION
Hi @jdxcode,

I just started using `gh` very recently. Nice tool, thanks! 👍 

Unfortunately, bash completion breaks if you change the base dir. This PR fixes the issue by using the same export `GH_BASE_DIR` defined in `bash/gh.bash` which falls back to the `~/src` folder.