### PR TITLE
Make remote repositories available during Fish repo completion

### DIFF
--- a/completions/bb.fish
+++ b/completions/bb.fish
@@ -10,7 +10,14 @@ end
 function __bb_repo_completion
   set -l cmd (commandline -o)
   set -l user $cmd[2]
-  command ls -L $BB_BASE_DIR/$GIT_HOST/$user
+  set -l repos (command ls -L $BB_BASE_DIR/$GIT_HOST/$user)
+  # if 'jq' is available and remote repository cache is not set yet
+  if type -q jq; and not set -q BB_REPOS_CACHE
+    set -l repos_url https://api.bitbucket.org/2.0/repositories/$user
+    set -xU BB_REPOS_CACHE (curl --silent $repos_url | jq -r '.values[] | select(.scm=="git") | .name')
+  end
+  set repos $repos $BB_REPOS_CACHE
+  printf "%s\n" $repos | sort | uniq -du
 end
 
 complete -c bb -n '__fish_is_token_n 2' --arguments '(__bb_user_completion)' --no-files


### PR DESCRIPTION
This commit makes remote public Github and Bitbucket repositories available during Fish shell repo completion process.

- It makes remote API request during completion flow
- Caches remote repository names in universal Fish variable
- Merges remote repository names with local ones
- Prepares sorted and unique repository names for Fish repo completion

It also checks for [jq](https://github.com/stedolan/jq) utility availability used for JSON data parsing coming from API. If it is not found then remote repository names will be simply unavailable for Fish completion.
