### PR TITLE
Add parent repository as upstream remote

### DIFF
--- a/functions/bb.fish
+++ b/functions/bb.fish
@@ -2,22 +2,34 @@ if not set -q BB_BASE_DIR
     set BB_BASE_DIR $HOME/src
 end
 
-function bb
-  set git_host bitbucket.org
-  set -l repo ""
+function __bb_add_upstream_remote --argument repo
+    set -l url https://api.bitbucket.org/2.0/repositories/$repo
+    set -l parent_repo (curl -s $url | jq -r 'select(.parent != null) | .parent | .full_name')
+    if test -n "$parent_repo"
+        git remote add upstream git@bitbucket.org:$parent_repo.git
+    end
+end
 
-  if [ (count $argv) -ne 2 ]
-    echo "USAGE: bb [user] [repo]"
-    return -1
-  end
+function bb -d "manage git repos"
+    set git_host bitbucket.org
+    set -l repo ""
 
-  set user $argv[1]
-  set repo $argv[2]
+    if [ (count $argv) -eq 1 ]
+        set repo $argv[1]
+    else if [ (count $argv) -eq 2 ]
+        set repo $argv[1]/$argv[2]
+    else
+        echo "USAGE: bb [user] [repo]"
+        return -1
+    end
 
-  set -l path $BB_BASE_DIR/$git_host/$user/$repo
-  if not test -d $path
-    git clone git@$git_host:$user/$repo.git $path
-  end
+    set -l path $BB_BASE_DIR/$git_host/$repo
+    if not test -d $path
+        git clone git@$git_host:$repo.git $path
+        cd $path
+        and git branch --set-upstream-to=origin/master master
+        and __bb_add_upstream_remote $repo
+    end
 
-  cd $path
+    cd $path
 end

--- a/functions/gh.fish
+++ b/functions/gh.fish
@@ -2,24 +2,34 @@ if not set -q GH_BASE_DIR
     set GH_BASE_DIR $HOME/src
 end
 
+function __gh_add_upstream_remote --argument repo
+    set -l url https://api.github.com/repos/$repo
+    set -l parent_repo (curl -s $url | jq -r 'select(.parent != null) | .parent | .full_name')
+    if test -n "$parent_repo"
+        git remote add upstream git@github.com:$parent_repo.git
+    end
+end
+
 function gh -d "manage git repos"
-  set git_host github.com
-  set -l repo ""
+    set git_host github.com
+    set -l repo ""
 
-  if [ (count $argv) -eq 1 ]
-    set repo $argv[1]
-  else if [ (count $argv) -eq 2 ]
-    set repo $argv[1]/$argv[2]
-  else
-    echo "USAGE: gh [user] [repo]"
-    return -1
-  end
+    if [ (count $argv) -eq 1 ]
+        set repo $argv[1]
+    else if [ (count $argv) -eq 2 ]
+        set repo $argv[1]/$argv[2]
+    else
+        echo "USAGE: gh [user] [repo]"
+        return -1
+    end
 
-  set -l path $GH_BASE_DIR/$git_host/$repo
-  if not test -d $path
-    git clone git@$git_host:$repo.git $path
-    cd $path; and git branch --set-upstream-to=origin/master master
-  end
+    set -l path $GH_BASE_DIR/$git_host/$repo
+    if not test -d $path
+        git clone git@$git_host:$repo.git $path
+        cd $path
+        and git branch --set-upstream-to=origin/master master
+        and __gh_add_upstream_remote $repo
+    end
 
-  cd $path
+    cd $path
 end


### PR DESCRIPTION
It's a common scenario when you want to contribute to some project you first fork it and later need to sync with the upstream repository. So, you need to add a remote to it. This PR does just that:

- Checks whether repository has a parent repository
- Adds _upstream_ remote parent repository ('_upstream_' name was chosen according to  the related [github help article](https://help.github.com/articles/configuring-a-remote-for-a-fork/) )

Note: committed files have indentation changes. It is not my arbitrary choice. They are formatted by [fish_indent](https://fishshell.com/docs/current/commands.html#fish_indent)